### PR TITLE
Introduce COMPATIBILITY_CHECK mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for hspec-golden-binary
 
+## 0.5.0.0  -- 2022-12-28
+* Introduce COMPATIBILITY_CHECK mode
+
 ## 0.4.0.0  -- 2022-12-19
 * Remove roundtripFromFile, but re use their code in order to fix goldenSpecs
 

--- a/hspec-golden-binary.cabal
+++ b/hspec-golden-binary.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hspec-golden-binary
-version:        0.3.0.0
+version:        0.5.0.0
 synopsis:       Use tests to monitor changes in Binary serialization
 description:    Use tests to monitor changes in Binary serialization
 category:       Testing

--- a/hspec-golden-binary.cabal
+++ b/hspec-golden-binary.cabal
@@ -59,6 +59,7 @@ test-suite test
       Test.Binary.GenericSpecsSpec
       Test.Types
       Test.Types.AlteredSelector
+      Test.Types.BackwardCompatible
       Test.Types.BrokenSerialization
       Test.Types.MismatchedToAndFromSerialization
       Test.Types.NewSelector

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-golden-binary
-version: 0.3.0.0
+version: 0.5.0.0
 synopsis: Use tests to monitor changes in Binary serialization
 description: Use tests to monitor changes in Binary serialization
 category: Testing

--- a/src/Test/Binary/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Binary/Internal/ADT/GoldenSpecs.hs
@@ -51,6 +51,9 @@ import qualified Data.Binary as Binary
 -- compare with golden file if it exists. Golden file encodes binary format of a
 -- type. It is recommended that you put the golden files under revision control
 -- to help monitor changes.
+-- COMPATIBILITY_CHECK mode: 
+--  By using this mode checks with golden files are in terms of type compatibility instead of byte for byte.
+--  This is useful for checking forward or backward compatibility of types that evolves in time.
 goldenADTSpecs ::
   forall a.
   (ToADTArbitrary a, Eq a, Show a, Binary.Binary a) =>
@@ -96,11 +99,16 @@ testConstructor Settings {..} moduleName typeName cap =
             then createGoldenFile sampleSize cap goldenFile
             else throwIO err
     if exists
-      then
-        compareWithGolden cap goldenFile
-          `catches` [ Handler (\(err :: HUnitFailure) -> fixIfFlag err),
-                      Handler (\(err :: DecodeError) -> fixIfFlag err)
-                    ]
+      then do
+          doCompatibility <- isJust <$> lookupEnv compatibilityCheckEnv
+          if doCompatibility
+            then
+              compareCompatibilityWithGolden cap goldenFile
+            else
+              compareWithGolden cap goldenFile
+                `catches` [ Handler (\(err :: HUnitFailure) -> fixIfFlag err),
+                            Handler (\(err :: DecodeError) -> fixIfFlag err)
+                          ]
       else do
         doCreate <- isJust <$> lookupEnv createMissingGoldenEnv
         if doCreate
@@ -118,7 +126,7 @@ testConstructor Settings {..} moduleName typeName cap =
         Nothing
 
 -- | The golden files already exist. Binary values with the same seed from
--- the golden file and compare the with the data in the golden file.
+-- the golden file and compare the with the data in the golden file (byte for byte check).
 compareWithGolden ::
   forall a.
   (ToADTArbitrary a, Eq a, Binary.Binary a) =>
@@ -129,6 +137,21 @@ compareWithGolden _cap goldenFile = do
   goldenBytes <- readFile goldenFile
   let (randomSamples :: RandomSamples a) = Binary.decode goldenBytes 
   Binary.encode randomSamples `shouldBe` goldenBytes
+
+-- | The golden files already exist. Binary values with the same seed from
+-- the golden file and compare the with the data in the golden file (at type compatibility level).
+compareCompatibilityWithGolden ::
+  forall a.
+  (ToADTArbitrary a, Eq a, Show a, Binary.Binary a) =>
+  ConstructorArbitraryPair a ->
+  FilePath ->
+  IO ()
+compareCompatibilityWithGolden _cap goldenFile = do
+  goldenBytes <- readFile goldenFile
+  let (randomSamples :: RandomSamples a) = Binary.decode goldenBytes 
+  let reEncodedGoldenBytes = Binary.encode randomSamples 
+  let (reDecodedRandomSamples :: RandomSamples a) = Binary.decode reEncodedGoldenBytes
+  randomSamples `shouldBe` reDecodedRandomSamples
 
 -- | The golden files do not exist. Create them for each constructor.
 createGoldenFile ::

--- a/src/Test/Binary/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Binary/Internal/ADT/GoldenSpecs.hs
@@ -125,8 +125,9 @@ testConstructor Settings {..} moduleName typeName cap =
       else
         Nothing
 
--- | The golden files already exist. Binary values with the same seed from
--- the golden file and compare the with the data in the golden file (byte for byte check).
+-- | PRE-condition: Golden file already exist.
+--   Try to decode golden file and encode it with the current encoder,
+--   then compare both encoded representations (byte for byte check).
 compareWithGolden ::
   forall a.
   (ToADTArbitrary a, Eq a, Binary.Binary a) =>
@@ -138,8 +139,9 @@ compareWithGolden _cap goldenFile = do
   let (randomSamples :: RandomSamples a) = Binary.decode goldenBytes 
   Binary.encode randomSamples `shouldBe` goldenBytes
 
--- | The golden files already exist. Binary values with the same seed from
--- the golden file and compare the with the data in the golden file (at type compatibility level).
+-- | PRE-condition: Golden file already exist.
+--   Try to decode the golden file, then re-encode and re-decode it again,
+--   finally compare initially decoded values with latest decoded ones (at type compatibility level)
 compareCompatibilityWithGolden ::
   forall a.
   (ToADTArbitrary a, Eq a, Show a, Binary.Binary a) =>

--- a/src/Test/Binary/Internal/GoldenSpecs.hs
+++ b/src/Test/Binary/Internal/GoldenSpecs.hs
@@ -111,8 +111,9 @@ goldenSpecsWithNotePlain settings@Settings {..} typeNameInfo@(TypeNameInfo {type
             then createGoldenfile @s settings proxy goldenFile
             else expectationFailure $ "Missing golden file: " <> goldenFile
 
--- | The golden files already exist. Binary values with the same seed from
--- the golden file and compare the with the data in the golden file (byte for byte check).
+-- | PRE-condition: Golden file already exist.
+--   Try to decode golden file and encode it with the current encoder,
+--   then compare both encoded representations (byte for byte check).
 compareWithGolden ::
   forall s a.
   (GoldenBinaryrConstraints s a, Arbitrary a, Eq a, Binary.Binary a) =>
@@ -126,8 +127,9 @@ compareWithGolden _settings _Proxy goldenFile _comparisonFile = do
   let (randomSamples :: RandomSamples a) = Binary.decode goldenBytes 
   Binary.encode randomSamples `shouldBe` goldenBytes
 
--- | The golden files already exist. Binary values with the same seed from
--- the golden file and compare the with the data in the golden file (at type compatibility level).
+-- | PRE-condition: Golden file already exist.
+--   Try to decode the golden file, then re-encode and re-decode it again,
+--   finally compare initially decoded values with latest decoded ones (at type compatibility level)
 compareCompatibilityWithGolden ::
   forall s a.
   (GoldenBinaryrConstraints s a, Arbitrary a, Eq a, Binary.Binary a) =>

--- a/src/Test/Binary/Internal/GoldenSpecs.hs
+++ b/src/Test/Binary/Internal/GoldenSpecs.hs
@@ -49,6 +49,9 @@ import qualified Data.Binary as Binary
 -- compare with golden file if it exists. Golden file encodes the serialized format of a
 -- type. It is recommended that you put the golden files under revision control
 -- to help monitor changes.
+-- COMPATIBILITY_CHECK mode: 
+--  By using this mode checks with golden files are in terms of type compatibility instead of byte for byte.
+--  This is useful for checking forward or backward compatibility of types that evolves in time.
 goldenSpecs ::
   forall s a.
   (GoldenBinaryrConstraints s a, Typeable a, Arbitrary a, Eq a, Binary.Binary a) =>
@@ -92,11 +95,16 @@ goldenSpecsWithNotePlain settings@Settings {..} typeNameInfo@(TypeNameInfo {type
               then createGoldenfile @s settings proxy goldenFile
               else throwIO err
       if exists
-        then
-          compareWithGolden @s settings proxy goldenFile comparisonFile
-            `catches` [ Handler (\(err :: HUnitFailure) -> fixIfFlag err),
-                        Handler (\(err :: DecodeError) -> fixIfFlag err)
-                      ]
+        then do
+          doCompatibility <- isJust <$> lookupEnv compatibilityCheckEnv
+          if doCompatibility
+            then
+              compareCompatibilityWithGolden @s settings proxy goldenFile comparisonFile
+            else
+              compareWithGolden @s settings proxy goldenFile comparisonFile
+                `catches` [ Handler (\(err :: HUnitFailure) -> fixIfFlag err),
+                            Handler (\(err :: DecodeError) -> fixIfFlag err)
+                          ]
         else do
           doCreate <- isJust <$> lookupEnv createMissingGoldenEnv
           if doCreate
@@ -104,7 +112,7 @@ goldenSpecsWithNotePlain settings@Settings {..} typeNameInfo@(TypeNameInfo {type
             else expectationFailure $ "Missing golden file: " <> goldenFile
 
 -- | The golden files already exist. Binary values with the same seed from
--- the golden file and compare the with the data in the golden file.
+-- the golden file and compare the with the data in the golden file (byte for byte check).
 compareWithGolden ::
   forall s a.
   (GoldenBinaryrConstraints s a, Arbitrary a, Eq a, Binary.Binary a) =>
@@ -117,6 +125,23 @@ compareWithGolden _settings _Proxy goldenFile _comparisonFile = do
   goldenBytes <- readFile goldenFile
   let (randomSamples :: RandomSamples a) = Binary.decode goldenBytes 
   Binary.encode randomSamples `shouldBe` goldenBytes
+
+-- | The golden files already exist. Binary values with the same seed from
+-- the golden file and compare the with the data in the golden file (at type compatibility level).
+compareCompatibilityWithGolden ::
+  forall s a.
+  (GoldenBinaryrConstraints s a, Arbitrary a, Eq a, Binary.Binary a) =>
+  Settings ->
+  Proxy (s a) ->
+  FilePath ->
+  ComparisonFile ->
+  IO ()
+compareCompatibilityWithGolden _settings _Proxy goldenFile _comparisonFile = do
+  goldenBytes <- readFile goldenFile
+  let (randomSamples :: RandomSamples a) = Binary.decode goldenBytes 
+  let reEncodedGoldenBytes = Binary.encode randomSamples 
+  let (reDecodedRandomSamples:: RandomSamples a) = Binary.decode reEncodedGoldenBytes
+  randomSamples `shouldBe` reDecodedRandomSamples
 
 -- | The golden files do not exist. Create it.
 createGoldenfile :: forall s a. (Ctx s (RandomSamples a), GoldenBinaryr s, Arbitrary a) => Settings -> Proxy (s a) -> FilePath -> IO ()

--- a/src/Test/Binary/Internal/Utils.hs
+++ b/src/Test/Binary/Internal/Utils.hs
@@ -221,3 +221,6 @@ createMissingGoldenEnv = "CREATE_MISSING_GOLDEN"
 
 recreateBrokenGoldenEnv :: String
 recreateBrokenGoldenEnv = "RECREATE_BROKEN_GOLDEN"
+
+compatibilityCheckEnv :: String 
+compatibilityCheckEnv = "COMPATIBILITY_CHECK"

--- a/test/Test/Binary/GenericSpecsSpec.hs
+++ b/test/Test/Binary/GenericSpecsSpec.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Proxy
 import System.Directory
 import Test.Binary.GenericSpecs
-import Test.Binary.Internal.Utils (RandomMismatchOption (..), RandomSamples(..), createMissingGoldenEnv, recreateBrokenGoldenEnv, LengthEncoded(..))
+import Test.Binary.Internal.Utils (RandomSamples(..), createMissingGoldenEnv, recreateBrokenGoldenEnv, LengthEncoded(..))
 import Test.Hspec
 -- various iterations of a Product and Sum Type and their serializations
 import qualified Test.Types as T

--- a/test/Test/Binary/GenericSpecsSpec.hs
+++ b/test/Test/Binary/GenericSpecsSpec.hs
@@ -8,12 +8,19 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Proxy
 import System.Directory
 import Test.Binary.GenericSpecs
-import Test.Binary.Internal.Utils (RandomSamples(..), createMissingGoldenEnv, recreateBrokenGoldenEnv, LengthEncoded(..))
+import Test.Binary.Internal.Utils 
+  ( RandomSamples(..), 
+    createMissingGoldenEnv,
+    recreateBrokenGoldenEnv,
+    compatibilityCheckEnv,
+    LengthEncoded(..)
+  )
 import Test.Hspec
 -- various iterations of a Product and Sum Type and their serializations
 import qualified Test.Types as T
 import qualified Test.Types.AlteredSelector as TAS
 import qualified Test.Types.BrokenSerialization as TBS
+import qualified Test.Types.BackwardCompatible as TBC
 import qualified Test.Types.MismatchedToAndFromSerialization as MTFS
 import qualified Test.Types.NewSelector as TNS
 import Test.Utils
@@ -22,10 +29,15 @@ unsetAllEnv :: IO ()
 unsetAllEnv = do
   unsetEnv createMissingGoldenEnv
   unsetEnv recreateBrokenGoldenEnv
+  unsetEnv compatibilityCheckEnv
 
 setCreateMissingGoldenEnv :: IO ()
 setCreateMissingGoldenEnv = 
   setEnv createMissingGoldenEnv "1"
+
+setCompatibilityCheckEnv :: IO ()
+setCompatibilityCheckEnv = 
+  setEnv compatibilityCheckEnv "1"
 
 spec :: Spec
 spec = before unsetAllEnv $ do
@@ -114,8 +126,8 @@ spec = before unsetAllEnv $ do
         goldenSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    it "goldenSpecs for types which have changed the values of put or get keys should fail to match the goldenFiles" $ do
-      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TBS.Person)
+    it "goldenSpecs for types which encoding is backward compatible should fail fail to match the goldenFiles" $ do
+      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenSpecs for types which have changed the values of put or get keys should fail to match the goldenFiles" $ do
       shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TNS.Person)
@@ -128,6 +140,31 @@ spec = before unsetAllEnv $ do
       shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy (LengthEncoded TBS.FailBinary))
       shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy (RandomSamples TBS.FailBinary))
 
+    it "goldenSpecs (with compatibility check mode on) should pass for existing golden files in which model types and serialization have not changed" $ do
+      setCompatibilityCheckEnv
+      setCreateMissingGoldenEnv
+      shouldProduceFailures 0 $ do
+        goldenSpecs defaultSettings (Proxy :: Proxy T.Person)
+        goldenSpecs defaultSettings (Proxy :: Proxy T.SumType)
+
+    it "goldenSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 0 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
+
+    it "goldenSpecs (with compatibility check mode on) for types which have new selector and using generic implementation of put or get keys should fail to match compatibility with goldenFiles" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TNS.Person)
+
+    it "goldenSpecs (with compatibility check mode on) for types which have altered the name of the selector and using generic implementation of put and get should fail to match compatibility with goldenFiles" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TAS.Person)
+
+    it "goldenSpecs (with compatibility check mode on) should not hide failures" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TBS.FailBinary)
+      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy (LengthEncoded TBS.FailBinary))
+      shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy (RandomSamples TBS.FailBinary))
+      
   describe "Test.Binary.GenericSpecs: goldenADTSpecs" $ do
     it "create golden test files" $ do
       setCreateMissingGoldenEnv
@@ -184,8 +221,8 @@ spec = before unsetAllEnv $ do
         goldenADTSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenADTSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    it "goldenADTSpecs for types which have changed the values of put or get keys should fail to match the goldenFiles" $ do
-      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBS.Person)
+    it "goldenADTSpecs for types which encoding is backward compatible should fail to match the goldenFiles" $ do
+      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenADTSpecs for types which have changed the values of put or get keys should fail to match the goldenFiles" $ do
       shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TNS.Person)
@@ -194,6 +231,31 @@ spec = before unsetAllEnv $ do
       shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TAS.Person)
 
     it "goldenADTSpecs should not hide failures" $ do
+      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBS.FailBinary)
+      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy (LengthEncoded TBS.FailBinary))
+      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy (RandomSamples TBS.FailBinary))
+
+    it "goldenADTSpecs (with compatibility check mode on) should pass for existing golden files in which model types and serialization have not changed" $ do
+      setCompatibilityCheckEnv
+      setCreateMissingGoldenEnv
+      shouldProduceFailures 0 $ do
+        goldenADTSpecs defaultSettings (Proxy :: Proxy T.Person)
+        goldenADTSpecs defaultSettings (Proxy :: Proxy T.SumType)
+
+    it "goldenADTSpecs (with compatibility check mode on) for types which encoding is backward compatible should succeed compatibility check" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 0 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBC.Person)
+
+    it "goldenADTSpecs (with compatibility check mode on) for types which have new selector and using generic implementation of put or get keys should fail to match compatibility with goldenFiles" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TNS.Person)
+
+    it "goldenADTSpecs (with compatibility check mode on) for types which have altered the name of the selector and using generic implementation of put and get should fail to match compatibility with goldenFiles" $ do
+      setCompatibilityCheckEnv
+      shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TAS.Person)
+
+    it "goldenADTSpecs (with compatibility check mode on) should not hide failures" $ do
+      setCompatibilityCheckEnv
       shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy TBS.FailBinary)
       shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy (LengthEncoded TBS.FailBinary))
       shouldProduceFailures 1 $ goldenADTSpecs defaultSettings (Proxy :: Proxy (RandomSamples TBS.FailBinary))

--- a/test/Test/Binary/GenericSpecsSpec.hs
+++ b/test/Test/Binary/GenericSpecsSpec.hs
@@ -126,7 +126,7 @@ spec = before unsetAllEnv $ do
         goldenSpecs defaultSettings (Proxy :: Proxy T.Person)
         goldenSpecs defaultSettings (Proxy :: Proxy T.SumType)
 
-    it "goldenSpecs for types which encoding is backward compatible should fail fail to match the goldenFiles" $ do
+    it "goldenSpecs for types which encoding is backward compatible should fail to match the goldenFiles" $ do
       shouldProduceFailures 1 $ goldenSpecs defaultSettings (Proxy :: Proxy TBC.Person)
 
     it "goldenSpecs for types which have changed the values of put or get keys should fail to match the goldenFiles" $ do

--- a/test/Test/Types/AlteredSelector.hs
+++ b/test/Test/Types/AlteredSelector.hs
@@ -19,16 +19,3 @@ instance ToADTArbitrary Person
 
 instance Arbitrary Person where
   arbitrary = genericArbitrary
-
-data SumType
-  = SumType1 Int
-  | SumType2 String Int
-  | SumType3 Double String Int
-  deriving (Eq, Show, Generic)
-
-instance Binary SumType
-
-instance ToADTArbitrary SumType
-
-instance Arbitrary SumType where
-  arbitrary = genericArbitrary

--- a/test/Test/Types/BackwardCompatible.hs
+++ b/test/Test/Types/BackwardCompatible.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+module Test.Types.BackwardCompatible where
+
+import Data.Binary
+import GHC.Generics
+import Test.QuickCheck
+import Test.QuickCheck.Arbitrary.ADT
+
+data Person = Person
+  { name :: String,
+    age :: Int
+  }
+  deriving (Eq, Show, Generic)
+
+data PersonWithoutAge = PersonWithoutAge
+  {
+    nameWithoutAge :: String
+  }
+  deriving (Eq, Show, Generic)
+
+instance Binary PersonWithoutAge
+
+instance Binary Person where
+  put = \(Person newName _) -> put (PersonWithoutAge newName)
+  get = do
+    PersonWithoutAge n <- get
+    return $ Person n 0 
+
+instance ToADTArbitrary Person
+
+instance Arbitrary Person where
+  arbitrary = genericArbitrary

--- a/test/Test/Types/BrokenSerialization.hs
+++ b/test/Test/Types/BrokenSerialization.hs
@@ -9,32 +9,6 @@ import GHC.Generics
 import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.ADT
 
-data Person = Person
-  { name :: String,
-    age :: Int
-  }
-  deriving (Eq, Show, Generic)
-
-data PersonWithoutAge = PersonWithoutAge
-  {
-    nameWithoutAge :: String
-  }
-  deriving (Eq, Show, Generic)
-
-instance Binary PersonWithoutAge
-
-instance Binary Person where
-  put = \(Person newName _) -> put (PersonWithoutAge newName)
-  get = do
-    PersonWithoutAge n <- get
-    return $ Person n 0 
-
-
-instance ToADTArbitrary Person
-
-instance Arbitrary Person where
-  arbitrary = genericArbitrary
-
 data SumType
   = SumType1 Int
   | SumType2 String Int

--- a/test/Test/Types/NewSelector.hs
+++ b/test/Test/Types/NewSelector.hs
@@ -20,16 +20,3 @@ instance ToADTArbitrary Person
 
 instance Arbitrary Person where
   arbitrary = genericArbitrary
-
-data SumType
-  = SumType1 Int
-  | SumType2 String Int
-  | SumType3 Double String Int
-  deriving (Eq, Show, Generic)
-
-instance Binary SumType
-
-instance ToADTArbitrary SumType
-
-instance Arbitrary SumType where
-  arbitrary = genericArbitrary


### PR DESCRIPTION
## Related Issue
https://github.com/plow-technologies/all/issues/9995


According to the spec:

### hspec-golden: Assertions - Compatibility check

Recent changes trigger us the idea of needing both; Assertions that are able to determine if golden files are changed or not, and assertions that are able to determine if backwards (or forward) compatibility is preserve.

As those assertions can’t happen simultaneously, we want to introduce the `COMPATIBILITY_CHECK` flag for `roundtripAndGolden` method in order to just run compatibility check and not other checks.

```
typeA <- decode serialA
serialA_new <- encode typeA
typeA_new <- decode serialA_new
compare typeA typeA_new
```
^  type compatibility check is a simplify version of the historical approach (remains allowing backward and forward compatibility checks).

About_ x86-arm64: 

Doing the byte-wise checking for arm and x86 produce different bytes, So for those cases, we should just ensure compatibility checks only.
